### PR TITLE
chore(deps): add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+---
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps-actions)
+    labels: [deps, ci]
+    groups:
+      actions-minor-patch:
+        update-types: [minor, patch]
+  # Go modules (gomod)
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps-gomod)
+    labels: [deps, go]
+    groups:
+      go-minor-patch:
+        update-types: [minor, patch]


### PR DESCRIPTION
Добавил еженедельные обновления зависимостей через Dependabot

⚙️ GitHub Actions

  - Minor/Patch обновления собираются в единый групповой PR (gha-minor-and-patch)
  - Major обновления идут отдельными PR по каждому экшену

🐹 Go (gomod)

  - Minor/Patch идут единым групповым PR (go-minor-patch).
  - Major — отдельными PR

Общие настройки: не более 5 одновременных PR на каждую экосистему; группировка снижает шум — мелкие апдейты приходят пачкой, а мажоры контролируются отдельно единым батчем

fyi @fey